### PR TITLE
Add ValueTask support

### DIFF
--- a/ObviousAwait/ObviousAwait.csproj
+++ b/ObviousAwait/ObviousAwait.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/ObviousAwait/ObviousAwait.csproj
+++ b/ObviousAwait/ObviousAwait.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard1.0;netstandard2.1</TargetFrameworks>
+    </PropertyGroup>
 
 </Project>

--- a/ObviousAwait/ObviousExtensions.cs
+++ b/ObviousAwait/ObviousExtensions.cs
@@ -54,6 +54,7 @@ namespace ObviousAwait
 
         #endregion
 
+#if NETSTANDARD2_1_OR_GREATER
         #region ValueTask
 
         /// <summary>
@@ -99,5 +100,6 @@ namespace ObviousAwait
         public static ConfiguredValueTaskAwaitable<T> FreeContext<T>(this ValueTask<T> t) => t.ConfigureAwait(false);
 
         #endregion
+#endif
     }
 }

--- a/ObviousAwait/ObviousExtensions.cs
+++ b/ObviousAwait/ObviousExtensions.cs
@@ -3,51 +3,101 @@ using System.Threading.Tasks;
 
 namespace ObviousAwait
 {
-	/// <summary>
-	/// Provides access to the extension methods KeepContext() and FreeContext() to alias ConfigureAwait(true/false).
-	/// </summary>
-	public static class ObviousExtensions
-	{
-		/// <summary>
-		/// Configures an awaiter to await a given task and captures the current context to make sure that
-		/// subsequent code runs on the same context, like the UI thread of example.
-		/// You may want to use this if your async code is coupled tightly to a user interface.
-		/// Equals to .ConfigureAwait(true).
-		/// </summary>
-		/// <param name="t">The task to configure an awaiter for.</param>
-		/// <returns>An object used to await this task.</returns>
-		public static ConfiguredTaskAwaitable KeepContext(this Task t) => t.ConfigureAwait(true);
+    /// <summary>
+    /// Provides access to the extension methods KeepContext() and FreeContext() to alias ConfigureAwait(true/false).
+    /// </summary>
+    public static class ObviousExtensions
+    {
+        #region Task
 
-		/// <summary>
-		/// Configures an awaiter to await a given task and captures the current context to make sure that
-		/// subsequent code runs on the same context, like the UI thread of example.
-		/// You may want to use this if your async code is coupled tightly to a user interface.
-		/// Equals to .ConfigureAwait(true).
-		/// </summary>
-		/// <typeparam name="T">The type of the result of the task to wait for.</typeparam>
-		/// <param name="t">The task to configure an awaiter for.</param>
-		/// <returns>An object used to await this task.</returns>
-		public static ConfiguredTaskAwaitable<T> KeepContext<T>(this Task<T> t) => t.ConfigureAwait(true);
+        /// <summary>
+        /// Configures an awaiter to await a given task and captures the current context to make sure that
+        /// subsequent code runs on the same context, like the UI thread of example.
+        /// You may want to use this if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(true).
+        /// </summary>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredTaskAwaitable KeepContext(this Task t) => t.ConfigureAwait(true);
 
-		/// <summary>
-		/// Configures an awaiter to await a given task without capturing a context. This means that
-		/// subsequent code is likely to run on another context than the one the awaited task was called from.
-		/// You should use this method on almost every awaited method. But pay attention if your async code is coupled tightly to a user interface.
-		/// Equals to .ConfigureAwait(false).
-		/// </summary>
-		/// <param name="t">The task to configure an awaiter for.</param>
-		/// <returns>An object used to await this task.</returns>
-		public static ConfiguredTaskAwaitable FreeContext(this Task t) => t.ConfigureAwait(false);
+        /// <summary>
+        /// Configures an awaiter to await a given task and captures the current context to make sure that
+        /// subsequent code runs on the same context, like the UI thread of example.
+        /// You may want to use this if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(true).
+        /// </summary>
+        /// <typeparam name="T">The type of the result of the task to wait for.</typeparam>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredTaskAwaitable<T> KeepContext<T>(this Task<T> t) => t.ConfigureAwait(true);
 
-		/// <summary>
-		/// Configures an awaiter to await a given task without capturing a context. This means that
-		/// subsequent code is likely to run on another context than the one the awaited task was called from.
-		/// You should use this method on almost every awaited method. But pay attention if your async code is coupled tightly to a user interface.
-		/// Equals to .ConfigureAwait(false).
-		/// </summary>
-		/// <typeparam name="T">The type of the result of the task to wait for.</typeparam>
-		/// <param name="t">The task to configure an awaiter for.</param>
-		/// <returns>An object used to await this task.</returns>
-		public static ConfiguredTaskAwaitable<T> FreeContext<T>(this Task<T> t) => t.ConfigureAwait(false);
-	}
+        /// <summary>
+        /// Configures an awaiter to await a given task without capturing a context. This means that
+        /// subsequent code is likely to run on another context than the one the awaited task was called from.
+        /// You should use this method on almost every awaited method. But pay attention if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(false).
+        /// </summary>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredTaskAwaitable FreeContext(this Task t) => t.ConfigureAwait(false);
+
+        /// <summary>
+        /// Configures an awaiter to await a given task without capturing a context. This means that
+        /// subsequent code is likely to run on another context than the one the awaited task was called from.
+        /// You should use this method on almost every awaited method. But pay attention if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(false).
+        /// </summary>
+        /// <typeparam name="T">The type of the result of the task to wait for.</typeparam>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredTaskAwaitable<T> FreeContext<T>(this Task<T> t) => t.ConfigureAwait(false);
+
+        #endregion
+
+        #region ValueTask
+
+        /// <summary>
+        /// Configures an awaiter to await a given task and captures the current context to make sure that
+        /// subsequent code runs on the same context, like the UI thread of example.
+        /// You may want to use this if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(true).
+        /// </summary>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredValueTaskAwaitable KeepContext(this ValueTask t) => t.ConfigureAwait(true);
+
+        /// <summary>
+        /// Configures an awaiter to await a given task and captures the current context to make sure that
+        /// subsequent code runs on the same context, like the UI thread of example.
+        /// You may want to use this if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(true).
+        /// </summary>
+        /// <typeparam name="T">The type of the result of the task to wait for.</typeparam>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredValueTaskAwaitable<T> KeepContext<T>(this ValueTask<T> t) => t.ConfigureAwait(true);
+
+        /// <summary>
+        /// Configures an awaiter to await a given task without capturing a context. This means that
+        /// subsequent code is likely to run on another context than the one the awaited task was called from.
+        /// You should use this method on almost every awaited method. But pay attention if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(false).
+        /// </summary>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredValueTaskAwaitable FreeContext(this ValueTask t) => t.ConfigureAwait(false);
+
+        /// <summary>
+        /// Configures an awaiter to await a given task without capturing a context. This means that
+        /// subsequent code is likely to run on another context than the one the awaited task was called from.
+        /// You should use this method on almost every awaited method. But pay attention if your async code is coupled tightly to a user interface.
+        /// Equals to .ConfigureAwait(false).
+        /// </summary>
+        /// <typeparam name="T">The type of the result of the task to wait for.</typeparam>
+        /// <param name="t">The task to configure an awaiter for.</param>
+        /// <returns>An object used to await this task.</returns>
+        public static ConfiguredValueTaskAwaitable<T> FreeContext<T>(this ValueTask<T> t) => t.ConfigureAwait(false);
+
+        #endregion
+    }
 }

--- a/ObviousConsole/Program.cs
+++ b/ObviousConsole/Program.cs
@@ -2,18 +2,35 @@
 
 namespace ObviousAwait.Console
 {
-	class Program
-	{
-		static async Task Main()
-		{
-			await Task.Delay(100).ConfigureAwait(false);
-			await Task.Delay(100).ConfigureAwait(true);
+    class Program
+    {
+        static async Task Main()
+        {
+            #region Task
 
-			await Task.Delay(100).ConfigureAwait(continueOnCapturedContext: false);
-			await Task.Delay(100).ConfigureAwait(continueOnCapturedContext: true);
+            await Task.Delay(100).ConfigureAwait(false);
+            await Task.Delay(100).ConfigureAwait(true);
 
-			await Task.Delay(100).KeepContext();
-			await Task.Delay(100).FreeContext();
-		}
-	}
+            await Task.Delay(100).ConfigureAwait(continueOnCapturedContext: false);
+            await Task.Delay(100).ConfigureAwait(continueOnCapturedContext: true);
+
+            await Task.Delay(100).KeepContext();
+            await Task.Delay(100).FreeContext();
+
+            #endregion
+
+            #region ValueTask
+
+            await new ValueTask(Task.Delay(100)).ConfigureAwait(false);
+            await new ValueTask(Task.Delay(100)).ConfigureAwait(true);
+
+            await new ValueTask(Task.Delay(100)).ConfigureAwait(continueOnCapturedContext: false);
+            await new ValueTask(Task.Delay(100)).ConfigureAwait(continueOnCapturedContext: true);
+
+            await new ValueTask(Task.Delay(100)).KeepContext();
+            await new ValueTask(Task.Delay(100)).FreeContext();
+
+            #endregion
+        }
+    }
 }


### PR DESCRIPTION
I had to create a new PR because I deleted the original fork I used for #2 

This PR adds support to ValueTasks which were added in .NET Core 2.0 (ValueTask<T> in 2.0 | ValueTask in 2.1) which means I had to increase the Target Framework version up to .NET Core 2.1

- [x] Add ValueTask support
- [ ] Update tests
